### PR TITLE
allow bedrock inference profile (id or arn) as valid LLM source

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,5 +1,4 @@
 strands-agents
-strands-mcp
 litellm
 loguru
 prompt-toolkit


### PR DESCRIPTION
Changes to allow bedrock inference profiles as valid LLM source. Following the argument convention: 

- ./yacba -m bedrock:<inference_profile_arn>
- ./yacba -m bedrock:<inference_profile_id>